### PR TITLE
Fix missing initialization in init()

### DIFF
--- a/hu-shing.cpp
+++ b/hu-shing.cpp
@@ -201,7 +201,7 @@ namespace HuShing {
 			while(!con[i].empty()) con[i].pop_back();
 			while(!child[i].empty()) child[i].pop_back();
 		}
-		n_arcs=0;
+		n_arcs=n_pqs=0;
 	}
 	void input(const vector<ll>& arr) {
 		n=arr.size();


### PR DESCRIPTION
init 함수에서 n_pqs가 초기화되지 않아 solve 함수를 여러 번 호출하면 오류가 발생합니다.